### PR TITLE
Exception code parameter fix

### DIFF
--- a/src/Malocher/Cqrs/Bus/BusException.php
+++ b/src/Malocher/Cqrs/Bus/BusException.php
@@ -31,12 +31,13 @@ class BusException extends \Exception
      * Creates a new BusException describing a default bus error.
      *
      * @param string $message Exception message
-     * @param \Exception $previousException  
+     * @param int $code Error code
+     * @param \Exception $previousException
      * @return BusException
      */
-    public static function defaultBusError($message, \Exception $previousException = null)
+    public static function defaultBusError($message, $code = null, \Exception $previousException = null)
     {
-        return new self('[Default Bus Error] ' . $message . "\n", $previousException);
+        return new self('[Default Bus Error] ' . $message . "\n", $code, $previousException);
     }
     
     /**


### PR DESCRIPTION
The code parameter was missing from the defaultBusError method. So, the BusException droped all previous exceptions.